### PR TITLE
add specific version on rust tool chain, to solve the compile problem

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-06-25"


### PR DESCRIPTION
in this repo, the toolchain.toml use "nightly" only, which will lead to the newest version 1.73.0-nightly. In this way, the newest version of nightly not support this repo. So I change "nightly" to "nightly-2023-06-25", it will solve the "cargo build " problem