### PR TITLE
fix(cargo): Fixing a version of arrayvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ smallvec = { version = "*", features = ["const_generics", "const_new", "serde"] 
 crossbeam = "*"
 sha3 = "0.10"
 lazy_static = "*"
-arrayvec = "*"
+arrayvec = "0.7"
 const_format = "0.2"
 bincode = "*"
 ethereum-types = "=0.14.1"


### PR DESCRIPTION
# What ❔

* Fixing a version of arrayvec to 0.7


## Why ❔

* Before it was a star - which caused it in some cases to use arrayvec 0.4 (if other crate depended on it) - which caused compilation errors (as 0.4 had only one template parameter)
