### PR TITLE
WitnessVec is abstract over Allocator

### DIFF
--- a/src/cs/implementations/convenience.rs
+++ b/src/cs/implementations/convenience.rs
@@ -8,6 +8,7 @@ use super::verifier::VerificationKey;
 use super::witness::WitnessVec;
 use crate::cs::cs_builder_verifier::CsVerifierBuilder;
 use crate::cs::oracle::merkle_tree::MerkleTreeWithCap;
+use crate::cs::traits::GoodAllocator;
 
 use super::transcript::Transcript;
 use crate::cs::traits::circuit::Circuit;
@@ -160,9 +161,10 @@ impl<
         TR: Transcript<F>,
         H: TreeHasher<F, Output = TR::CompatibleCap>,
         POW: PoWRunner,
+        A: GoodAllocator,
     >(
         &self,
-        witness_vector: &WitnessVec<F>,
+        witness_vector: &WitnessVec<F, A>,
         proof_config: ProofConfig,
         setup_base: &SetupBaseStorage<F, P>,
         setup: &SetupStorage<F, P>,


### PR DESCRIPTION
# What ❔

WitnessVec is abstract over Allocator and GoodAllocator is 'static

## Why ❔

In case witness gen and gpu-proving process are on the different machines we want to speedup data transfer between host and gpu device by placing data to the statically allocated pinned buffer. So it is useful to change definition of the `WitnessVec` and make it generic over custom allocator. 
