### PR TITLE
Vec<u32, A> and Vec<u64,A> are MemcopySerializeable

### DIFF
--- a/src/cs/implementations/fast_serialization.rs
+++ b/src/cs/implementations/fast_serialization.rs
@@ -231,7 +231,7 @@ where
         let mut result: Vec<u32, A> = Vec::with_capacity_in(capacity, A::default());
         let mut tmp =
             unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
-        src.read_exact(tmp).map_err(Box::new);
+        src.read_exact(tmp).map_err(Box::new)?;
         unsafe { result.set_len(capacity) };
         Ok(result)
     }
@@ -261,7 +261,7 @@ where
         let mut result: Vec<u64, A> = Vec::with_capacity_in(capacity, A::default());
         let mut tmp =
             unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
-        src.read_exact(tmp).map_err(Box::new);
+        src.read_exact(tmp).map_err(Box::new)?;
         unsafe { result.set_len(capacity) };
 
         Ok(result)

--- a/src/cs/implementations/fast_serialization.rs
+++ b/src/cs/implementations/fast_serialization.rs
@@ -229,8 +229,7 @@ where
 
         let num_bytes = capacity * std::mem::size_of::<u32>();
         let mut result: Vec<u32, A> = Vec::with_capacity_in(capacity, A::default());
-        let mut tmp =
-            unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
+        let tmp = unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
         src.read_exact(tmp).map_err(Box::new)?;
         unsafe { result.set_len(capacity) };
         Ok(result)
@@ -259,8 +258,7 @@ where
 
         let num_bytes = capacity * std::mem::size_of::<u64>();
         let mut result: Vec<u64, A> = Vec::with_capacity_in(capacity, A::default());
-        let mut tmp =
-            unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
+        let tmp = unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
         src.read_exact(tmp).map_err(Box::new)?;
         unsafe { result.set_len(capacity) };
 

--- a/src/cs/implementations/fast_serialization.rs
+++ b/src/cs/implementations/fast_serialization.rs
@@ -207,6 +207,67 @@ where
     }
 }
 
+impl<A: GoodAllocator> MemcopySerializable for Vec<u32, A>
+where
+    Self: 'static,
+{
+    fn write_into_buffer<W: Write>(&self, mut dst: W) -> Result<(), Box<dyn Error>> {
+        let len_le_bytes = (self.len() as u64).to_le_bytes();
+        dst.write_all(&len_le_bytes).map_err(Box::new)?;
+
+        let num_bytes = self.len() * std::mem::size_of::<u32>();
+        let src = unsafe { slice::from_raw_parts(self.as_ptr().cast(), num_bytes) };
+        dst.write_all(src).map_err(Box::new)?;
+
+        Ok(())
+    }
+
+    fn read_from_buffer<R: Read>(mut src: R) -> Result<Self, Box<dyn Error>> {
+        let mut len_le_bytes = [0u8; 8];
+        src.read_exact(&mut len_le_bytes).map_err(Box::new)?;
+        let capacity = u64::from_le_bytes(len_le_bytes) as usize;
+
+        let num_bytes = capacity * std::mem::size_of::<u32>();
+        let mut result: Vec<u32, A> = Vec::with_capacity_in(capacity, A::default());
+        let mut tmp =
+            unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
+        src.read_exact(tmp).map_err(Box::new);
+        unsafe { result.set_len(capacity) };
+        Ok(result)
+    }
+}
+
+impl<A: GoodAllocator> MemcopySerializable for Vec<u64, A>
+where
+    Self: 'static,
+{
+    fn write_into_buffer<W: Write>(&self, mut dst: W) -> Result<(), Box<dyn Error>> {
+        let len_le_bytes = (self.len() as u64).to_le_bytes();
+        dst.write_all(&len_le_bytes).map_err(Box::new)?;
+
+        let num_bytes = self.len() * std::mem::size_of::<u64>();
+        let src = unsafe { slice::from_raw_parts(self.as_ptr().cast(), num_bytes) };
+        dst.write_all(src).map_err(Box::new)?;
+
+        Ok(())
+    }
+
+    fn read_from_buffer<R: Read>(mut src: R) -> Result<Self, Box<dyn Error>> {
+        let mut len_le_bytes = [0u8; 8];
+        src.read_exact(&mut len_le_bytes).map_err(Box::new)?;
+        let capacity = u64::from_le_bytes(len_le_bytes) as usize;
+
+        let num_bytes = capacity * std::mem::size_of::<u64>();
+        let mut result: Vec<u64, A> = Vec::with_capacity_in(capacity, A::default());
+        let mut tmp =
+            unsafe { std::slice::from_raw_parts_mut(result.as_mut_ptr().cast(), num_bytes) };
+        src.read_exact(tmp).map_err(Box::new);
+        unsafe { result.set_len(capacity) };
+
+        Ok(result)
+    }
+}
+
 impl<F: SmallField, const N: usize, A: GoodAllocator> MemcopySerializable for Vec<[F; N], A>
 where
     Self: 'static,

--- a/src/cs/implementations/hints/mod.rs
+++ b/src/cs/implementations/hints/mod.rs
@@ -50,8 +50,9 @@ impl MemcopySerializable for Vec<Variable> {
         let len_le_bytes = (len as u64).to_le_bytes();
         dst.write_all(&len_le_bytes).map_err(Box::new)?;
 
+        let num_bytes = len * std::mem::size_of::<Variable>();
         let ptr: *const u8 = self.as_ptr().cast();
-        let src = unsafe { std::slice::from_raw_parts(ptr, len) };
+        let src = unsafe { std::slice::from_raw_parts(ptr, num_bytes) };
 
         dst.write_all(src).map_err(Box::new)?;
 
@@ -90,8 +91,9 @@ impl MemcopySerializable for Vec<Witness> {
         let len_le_bytes = (len as u64).to_le_bytes();
         dst.write_all(&len_le_bytes).map_err(Box::new)?;
 
+        let num_bytes = len * std::mem::size_of::<Variable>();
         let ptr: *const u8 = self.as_ptr().cast();
-        let src = unsafe { std::slice::from_raw_parts(ptr, len) };
+        let src = unsafe { std::slice::from_raw_parts(ptr, num_bytes) };
 
         dst.write_all(src).map_err(Box::new)?;
 


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->
Vec<u32, A> and Vec<u64, A> implements `MemcopySerializeable` trait.

## Why ❔

Precomputed setup of the gpu prover stores hints as vector of u32. Having implementation of this trait for `Vec<u32, A>` will allow faster serialization and deserialization + better trait specifications of the service layer. 
