### PR TITLE
Set single threaded resolver as default

### DIFF
--- a/src/dag/mod.rs
+++ b/src/dag/mod.rs
@@ -145,4 +145,4 @@ pub type StCircuitResolver<F, CFG> = resolvers::StCircuitResolver<F, CFG>;
 pub type MtCircuitResolver<F, CFG> =
     resolvers::MtCircuitResolver<F, LiveResolverSorter<F, CFG>, CFG>;
 
-pub type DefaultCircuitResolver<F, CFG> = MtCircuitResolver<F, CFG>;
+pub type DefaultCircuitResolver<F, CFG> = StCircuitResolver<F, CFG>;


### PR DESCRIPTION
Sets the single threaded circuit resolver as default. It should provide better performance, efficiency and memory consumption.