### PR TITLE
Fixed empty resolver bug

### DIFF
--- a/src/dag/resolvers/mt/mod.rs
+++ b/src/dag/resolvers/mt/mod.rs
@@ -534,6 +534,16 @@ mod test {
     }
 
     #[test]
+    fn resolves_empty() {
+        let mut storage =
+            MtCircuitResolver::<F, LiveResolverSorter<F, Cfg>, Cfg>::new(CircuitResolverOpts {
+                max_variables: 100,
+                desired_parallelism: 16,
+            });
+        storage.wait_till_resolved();
+    }
+
+    #[test]
     fn resolves_playback_mode() {
         let mut storage =
             MtCircuitResolver::<F, LiveResolverSorter<F, Cfg>, Cfg>::new(CircuitResolverOpts {

--- a/src/dag/resolvers/mt/sorters/sorter_live.rs
+++ b/src/dag/resolvers/mt/sorters/sorter_live.rs
@@ -606,7 +606,8 @@ impl<F: SmallField, Cfg: CSResolverConfig, RW: ResolutionRecordWriter> ResolverS
         for (i, item) in self.record.items[..].iter_mut().enumerate() {
             debug_assert_eq!(i, item.added_at as usize);
         }
-        self.record.values_count = 1 + unsafe { self.common.values.u_deref().max_tracked } as usize;
+
+        self.record.values_count = unsafe { self.common.values.u_deref().max_tracked + 1 } as usize;
         self.record.registrations_count = self.stats.registrations_added as usize;
 
         if cfg!(cr_paranoia_mode) || crate::dag::resolvers::mt::PARANOIA {


### PR DESCRIPTION
# What ❔

* Fixed overflow issue for empty resolver.
* Added a test.


## Why ❔

* When resolver was empty, the max_tracked could be -1, and when doing a cast, it was mapped to max usize, and then it overflows.
