### PR TITLE
Fix avx512 poseidon2 compilation config

### DIFF
--- a/src/implementations/poseidon2/mod.rs
+++ b/src/implementations/poseidon2/mod.rs
@@ -4,11 +4,9 @@ use crate::field::goldilocks::GoldilocksField;
 pub mod params;
 
 pub mod state_generic_impl;
-#[cfg(not(all(
+#[cfg(not(any(
     feature = "include_packed_simd",
-    any(
-        target_feature = "neon",
-        target_feature = "avx2",
+    all(
         target_feature = "avx512bw",
         target_feature = "avx512cd",
         target_feature = "avx512dq",
@@ -48,7 +46,6 @@ pub mod state_vectorized_double;
 pub use state_vectorized_double::*;
 
 #[cfg(all(
-    feature = "include_packed_simd",
     target_feature = "avx512bw",
     target_feature = "avx512cd",
     target_feature = "avx512dq",
@@ -58,7 +55,6 @@ pub use state_vectorized_double::*;
 pub mod state_avx512;
 
 #[cfg(all(
-    feature = "include_packed_simd",
     target_feature = "avx512bw",
     target_feature = "avx512cd",
     target_feature = "avx512dq",

--- a/src/implementations/poseidon2/mod.rs
+++ b/src/implementations/poseidon2/mod.rs
@@ -5,13 +5,16 @@ pub mod params;
 
 pub mod state_generic_impl;
 #[cfg(not(any(
-    feature = "include_packed_simd",
     all(
         target_feature = "avx512bw",
         target_feature = "avx512cd",
         target_feature = "avx512dq",
         target_feature = "avx512f",
         target_feature = "avx512vl",
+    ),
+    all(
+        feature = "include_packed_simd",
+        any(target_feature = "neon", target_feature = "avx2")
     )
 )))]
 pub use state_generic_impl::*;

--- a/src/implementations/poseidon2/state_avx512.rs
+++ b/src/implementations/poseidon2/state_avx512.rs
@@ -24,11 +24,6 @@ impl Aligned {
     }
 }
 
-// we also need holder for SIMD targets, because u64x4 has smaller alignment than u64x8
-#[derive(Clone, Copy)]
-#[repr(C, align(64))]
-struct U128x4Holder([packed_simd::u128x4; 3]);
-
 impl std::fmt::Debug for State {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@
 #![feature(iter_array_chunks)]
 // #![recursion_limit = "1024"]
 #![feature(avx512_target_feature)]
+#![cfg_attr(target_feature = "avx512bw", feature(stdarch_x86_avx512))]
 #![feature(associated_type_defaults)]
 #![feature(trait_alias)]
 #![feature(vec_push_within_capacity)]


### PR DESCRIPTION
Currently Poseidon2 can't be compiled using `avx512` features on the corresponding platforms without the "include_packed_simd" feature. But actually this feature is not needed for compilation.
